### PR TITLE
claude abstract fix

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -236,7 +236,7 @@ blockquote {
     a {
       i::before {
         color: var(--global-text-color);
-        transition-property: all 0.2s ease-in-out;
+        transition: all 0.2s ease-in-out;
       }
 
       &:hover {
@@ -310,7 +310,7 @@ blockquote {
     a {
       i::before {
         color: var(--global-text-color);
-        transition-property: all 0.2s ease-in-out;
+        transition: all 0.2s ease-in-out;
       }
 
       &:hover {
@@ -683,10 +683,9 @@ footer.sticky-bottom {
         max-height: 0px;
         overflow: hidden;
         text-align: justify;
-        transition-property: 0.15s ease;
-        -moz-transition: 0.15s ease;
-        -ms-transition: 0.15s ease;
-        -o-transition: 0.15s ease;
+        -moz-transition: all 0.15s ease;
+        -ms-transition: all 0.15s ease;
+        -o-transition: all 0.15s ease;
         transition: all 0.15s ease;
 
         p {
@@ -703,10 +702,9 @@ footer.sticky-bottom {
 
       .hidden.open {
         max-height: 100em;
-        transition-property: 0.15s ease;
-        -moz-transition: 0.15s ease;
-        -ms-transition: 0.15s ease;
-        -o-transition: 0.15s ease;
+        -moz-transition: all 0.15s ease;
+        -ms-transition: all 0.15s ease;
+        -o-transition: all 0.15s ease;
         transition: all 0.15s ease;
       }
 


### PR DESCRIPTION
…tionality

Fixed multiple instances of invalid CSS syntax where transition-property was incorrectly set to duration and easing values instead of property names. Changed from:
  transition-property: 0.15s ease;
To:
  transition: all 0.15s ease;

This was preventing the abstract boxes from opening/closing properly on the publications page.

Fixes:
- Lines 686, 706: .hidden and .hidden.open classes
- Lines 239, 313: Social icon transitions